### PR TITLE
higher CPU limits for Longhorn and low CPU limits for the registry

### DIFF
--- a/cluster/Vagrantfile
+++ b/cluster/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   config.vm.disk :disk, size: "64GB", primary: true
 
   config.vm.provider "virtualbox" do |vbox|
-    vbox.cpus = 6
+    vbox.cpus = 4
     vbox.memory = GBasMB 16
   end
 

--- a/cluster/longhorn/main.tf
+++ b/cluster/longhorn/main.tf
@@ -21,9 +21,9 @@ resource "helm_release" "longhorn" {
       defaultSettings:
         defaultReplicaCount: 1
         allowNodeDrainWithLastHealthyReplica: true
-        guaranteedEngineCPU: 1
-        guaranteedEngineManagerCPU: 1
-        guaranteedReplicaManagerCPU: 1
+        guaranteedEngineCPU: 2
+        guaranteedEngineManagerCPU: 2
+        guaranteedReplicaManagerCPU: 2
     EOT
   ]
 }

--- a/cluster/registry/main.tf
+++ b/cluster/registry/main.tf
@@ -95,6 +95,14 @@ resource "kubernetes_stateful_set" "registry" {
             name       = "registry-tls"
             mount_path = "/run/secrets/registry-tls"
           }
+          resources {
+            requests = {
+              cpu = "0.25"
+            }
+            limits = {
+              cpu = "0.25"
+            }
+          }
         }
         volume {
           name = "registry-tls"


### PR DESCRIPTION
Make the Longhorn system a bit more stable by restricting the registry's CPU usage while increasing the Longhorn's allotment.